### PR TITLE
Use dockerize for elasticsearch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM openjdk:8u151-jdk
 LABEL maintainer "h-otter <h-otter@outlook.jp>"
 
 ENV JG_VERSION 0.2.0
+ENV DOCKERIZE_VERSION v0.6.0
 
 RUN curl -fsSLO https://github.com/JanusGraph/janusgraph/releases/download/v${JG_VERSION}/janusgraph-${JG_VERSION}-hadoop2.zip && \
     unzip janusgraph-${JG_VERSION}-hadoop2.zip && \
@@ -10,8 +11,10 @@ RUN curl -fsSLO https://github.com/JanusGraph/janusgraph/releases/download/v${JG
 WORKDIR janusgraph-${JG_VERSION}-hadoop2
 COPY conf/gremlin-server/janusgraph-cassandra-es-server.properties conf/gremlin-server/janusgraph-cassandra-es-server.properties
 
+RUN curl -fsSLO https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
+    rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 EXPOSE 8182
+
 CMD ["bin/gremlin-server.sh"]
-
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
 version: '2'
 services:
   janusgraph:
-    image: hotter/janusgraph-gremlin
+    image: n0stack/janusgraph-gremlin
+    build: .
     command:
-      - sh
-      - -c
-      - "sleep 10 && bin/gremlin-server.sh"
+      - dockerize
+      - -wait
+      - tcp://elasticsearch:9200
+      - -timeout
+      - 30s
+      - bin/gremlin-server.sh
     ports:
       - "8182:8182"
     depends_on:


### PR DESCRIPTION
Ref: [jwilder/dockerize](https://github.com/jwilder/dockerize)

- Use dockerize command to wait 9200/tcp of elasticsearch accessible.
- (Edit image name in docker-compose.yml)